### PR TITLE
Compile error setting properties in WEPopoverContainerView

### DIFF
--- a/Classes/Popover/WEPopoverContainerView.m
+++ b/Classes/Popover/WEPopoverContainerView.m
@@ -45,7 +45,7 @@ permittedArrowDirections:(UIPopoverArrowDirection)permittedArrowDirections
 		properties:(WEPopoverContainerViewProperties *)theProperties {
 	if ((self = [super initWithFrame:CGRectZero])) {
 		
-		self.properties = theProperties;
+		[self setProperties:theProperties];
 		correctedSize = CGSizeMake(theSize.width + properties.leftBgMargin + properties.rightBgMargin + properties.leftContentMargin + properties.rightContentMargin, 
 								   theSize.height + properties.topBgMargin + properties.bottomBgMargin + properties.topContentMargin + properties.bottomContentMargin);	
 		[self determineGeometryForSize:correctedSize anchorRect:anchorRect displayArea:displayArea permittedArrowDirections:permittedArrowDirections];


### PR DESCRIPTION
I get a compile error trying to use dot syntax to set the "properties" ivar, since it's not a declared property. I updated it to just call your setProperties method.
