### PR TITLE
Removing the "Unused Entity" warning in WEPopoverController.m

### DIFF
--- a/Classes/Popover/WEPopoverController.m
+++ b/Classes/Popover/WEPopoverController.m
@@ -123,8 +123,14 @@
 	
 	[self dismissPopoverAnimated:NO];
 	
+	// http://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused"
+
 	//First force a load view for the contentViewController so the popoverContentSize is properly initialized
 	contentViewController.view;
+	
+#pragma GCC diagnostic pop
 	
 	if (CGSizeEqualToSize(popoverContentSize, CGSizeZero)) {
 		popoverContentSize = contentViewController.contentSizeForViewInPopover;


### PR DESCRIPTION
Adding inline compiler instructions to avoid the following warning:

"WEPopoverController.m: warning: Unused Entity Issue: Property access result unused - getters should not be used for side effects"
