### PR TITLE
Makes <WEPopoverControllerDelegate> Methods optional to implement, checks for implementation before invoking them

### DIFF
--- a/Classes/Popover/WEPopoverController.h
+++ b/Classes/Popover/WEPopoverController.h
@@ -15,6 +15,8 @@
 
 @protocol WEPopoverControllerDelegate<NSObject>
 
+@optional
+
 - (void)popoverControllerDidDismissPopover:(WEPopoverController *)popoverController;
 - (BOOL)popoverControllerShouldDismissPopover:(WEPopoverController *)popoverController;
 

--- a/Classes/Popover/WEPopoverController.m
+++ b/Classes/Popover/WEPopoverController.m
@@ -106,7 +106,10 @@
 		
 		if (userInitiatedDismissal) {
 			//Only send message to delegate in case the user initiated this event, which is if he touched outside the view
-			[delegate popoverControllerDidDismissPopover:self];
+			if(delegate != nil && [delegate conformsToProtocol:@protocol(WEPopoverControllerDelegate)] &&
+			   [delegate respondsToSelector:@selector(popoverControllerDidDismissPopover:)]) {
+				[delegate popoverControllerDidDismissPopover:self];
+			}
 		}
 	}
 }
@@ -246,9 +249,13 @@
 
 - (void)viewWasTouched:(WETouchableView *)view {
 	if (popoverVisible) {
-		if (!delegate || [delegate popoverControllerShouldDismissPopover:self]) {
-			[self dismissPopoverAnimated:YES userInitiated:YES];
+		BOOL shouldDismiss = YES;
+		if(delegate != nil && [delegate conformsToProtocol:@protocol(WEPopoverControllerDelegate)] &&
+		   [delegate respondsToSelector:@selector(popoverControllerShouldDismissPopover:)]) {
+			shouldDismiss = [delegate popoverControllerShouldDismissPopover:self];
 		}
+		if(shouldDismiss)
+			[self dismissPopoverAnimated:YES userInitiated:YES];
 	}
 }
 


### PR DESCRIPTION
Checks for delegate conformance and if the methods are actually implemented before calling them
